### PR TITLE
feat: add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules


### PR DESCRIPTION
### What does this PR do?

Adds .gitignore file to prevent `node_modules` and `dist` folder and its files from being tracked and versioned.
