### PR TITLE
fix(build): disable chunks generation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
   entry: './src/index.tsx',
@@ -59,6 +60,9 @@ module.exports = {
       patterns: [
         { from: 'manifest.json', to: './' }, // Copy manifest.json to static/ in the output folder
       ],
+    }),
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
     }),
   ],
 };


### PR DESCRIPTION
### What does this PR do?
Limit chunks to 1 so we always have one js file for the plugin.

### Motivation
Some dependencies can use dynamic import to load js files on demand (this happened with [react-player](https://www.npmjs.com/package/react-player)), this causes webpack to generate several js files as the build result, which can cause problems when deploying.
