### PR TITLE
[0.1.x] chore: replaces deprecated `onBeforeSetupMiddleware` webpack hook

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
     client: {
       overlay: false,
     },
-    onBeforeSetupMiddleware: (devServer) => {
+    setupMiddlewares: (middlewares, devServer) => {
       if (!devServer) {
         throw new Error('webpack-dev-server is not defined');
       }
@@ -29,6 +29,8 @@ module.exports = {
       devServer.app.get('/manifest.json', (req, res) => {
         res.sendFile(path.resolve(__dirname, 'manifest.json'));
       });
+
+      return middlewares;
     },
   },
   module: {


### PR DESCRIPTION
### What does this PR do?

Replaces the deprecated hook used to serve the manifest.json file when running webpack dev server by a newer one `setupMiddlewares`.

### Closes Issue(s)
Closes #17 